### PR TITLE
gts28vewifi: proprietary-files: Update default source note

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -1,3 +1,5 @@
+# Samsung Package Version: T713XXS2BSG1_T713PHN2BSB1_PHN, unless pinned
+
 # Sensors
 lib64/hw/sensors.msm8952.so
 vendor/etc/yas_set.cfg


### PR DESCRIPTION
Sources from T713XXS2BSG1_T713PHN2BSB1_PHN

Change-Id: I90acbb2b75a53097259f53260ae1d1549854c4f3